### PR TITLE
[IMP] [2480583] Increasing flexibility for invoice uom flow (#3)

### DIFF
--- a/product_eggemoa/__manifest__.py
+++ b/product_eggemoa/__manifest__.py
@@ -8,11 +8,12 @@
     "author": "Odoo PS",
     "website": "http://www.odoo.com",
     "license": "OEEL-1",
-    "depends": ["account", "product", "stock_account",],
+    "depends": ["account", "product", "stock_account", "sale"],
     "data": [
         "views/product_template.xml",
         "views/product_product.xml",
         "views/account_invoice.xml",
+        "views/sale_order.xml",
     ],
     # Only used to link to the analysis / Ps-tech store
     "task_id": [2480583],

--- a/product_eggemoa/models/__init__.py
+++ b/product_eggemoa/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_template
 from . import account_invoice_line
 from . import product_product
+from . import sale_order_line

--- a/product_eggemoa/models/account_invoice_line.py
+++ b/product_eggemoa/models/account_invoice_line.py
@@ -1,4 +1,5 @@
 from odoo import models, fields, api
+from odoo.addons import decimal_precision
 
 
 class AccountInvoiceLine(models.Model):
@@ -7,8 +8,15 @@ class AccountInvoiceLine(models.Model):
     secondary_uom_quantity = fields.Float(
         string="Invoice Quantity",
         compute="_compute_secondary_uom_quantity",
-        inverse="_inverse_set_secondary_uom_quantity",
         store=True,
+        readonly=False,
+    )
+
+    secondary_uom_ratio = fields.Float(
+        string="Invoice UoM Ratio",
+        compute="_compute_secondary_uom_ratio",
+        store=True,
+        readonly=False,
     )
 
     secondary_uom_id = fields.Many2one(
@@ -20,28 +28,78 @@ class AccountInvoiceLine(models.Model):
         readonly=False,
     )
 
-    @api.depends("product_id")
+    secondary_uom_price_unit = fields.Float(
+        string="Invoice UoM Price Unit",
+        compute="_compute_secondary_uom_price_unit",
+        store=True,
+        digits=decimal_precision.get_precision("Product Price"),
+        readonly=False,
+    )
+
+    @api.onchange("quantity", "secondary_uom_ratio")
+    def _onchange_quantity_info(self):
+        self.secondary_uom_quantity = self.product_id.convert_secondary_uom(
+            self.quantity,
+            self.uom_id,
+            self.secondary_uom_id or self.uom_id,
+            self.secondary_uom_ratio,
+        )
+
+    @api.depends("price_unit")
+    def _compute_secondary_uom_price_unit(self):
+        for rec in self:
+            rec.secondary_uom_price_unit = rec.product_id.convert_secondary_price(
+                rec.price_unit,
+                rec.uom_id,
+                rec.secondary_uom_id,
+                rec.secondary_uom_ratio,
+            )
+
+    @api.onchange("secondary_uom_quantity")
+    def _onchange_secondary_uom_quantity(self):
+        self.secondary_uom_ratio = (
+            self.secondary_uom_quantity / self.quantity
+            if self.quantity
+            else self.secondary_uom_ratio
+        )
+
+    @api.onchange("secondary_uom_price_unit", "secondary_uom_ratio")
+    def _onchange_secondary_uom_price_unit(self):
+        self.price_unit = self.product_id.convert_secondary_price(
+            self.secondary_uom_price_unit,
+            self.secondary_uom_id,
+            self.uom_id,
+            self.secondary_uom_ratio,
+        )
+
+    @api.depends("product_id", "sale_line_ids")
+    def _compute_secondary_uom_ratio(self):
+        for rec in self:
+            rec.secondary_uom_ratio = (
+                rec.sale_line_ids[0].secondary_uom_ratio
+                if rec.sale_line_ids
+                else (
+                    rec.product_id.secondary_uom_ratio
+                    if rec.product_id.secondary_uom_id
+                    else 1
+                )
+            )
+
+    @api.depends("product_id", "sale_line_ids")
     def _compute_secondary_uom_id(self):
         for rec in self:
             rec.secondary_uom_id = (
-                rec.product_id.secondary_uom_id or rec.product_id.uom_id
+                rec.sale_line_ids[0].secondary_uom_id
+                if rec.sale_line_ids
+                else (rec.product_id.secondary_uom_id or rec.product_id.uom_id)
             )
 
     @api.depends("quantity", "uom_id", "secondary_uom_id")
     def _compute_secondary_uom_quantity(self):
         for rec in self:
             rec.secondary_uom_quantity = rec.product_id.convert_secondary_uom(
-                rec.quantity, rec.uom_id, rec.secondary_uom_id,
+                rec.quantity,
+                rec.uom_id,
+                rec.secondary_uom_id or rec.uom_id,
+                rec.secondary_uom_ratio,
             )
-
-    def _inverse_set_secondary_uom_quantity(self):
-        for rec in self:
-            rec.quantity = rec.product_id.convert_secondary_uom(
-                rec.secondary_uom_quantity, rec.secondary_uom_id, rec.uom_id
-            )
-
-    @api.onchange("secondary_uom_quantity")
-    def _onchange_secondary_uom_quantity(self):
-        self.quantity = self.product_id.convert_secondary_uom(
-            self.secondary_uom_quantity, self.secondary_uom_id, self.uom_id
-        )

--- a/product_eggemoa/models/product_product.py
+++ b/product_eggemoa/models/product_product.py
@@ -1,4 +1,7 @@
-from odoo import models, fields
+from odoo import models, fields, api, _
+from odoo.tools.float_utils import float_round
+from odoo.addons import decimal_precision
+from odoo.exceptions import ValidationError
 
 
 class ProductProduct(models.Model):
@@ -8,13 +11,41 @@ class ProductProduct(models.Model):
         string="Secondary Qty at Date", compute="_compute_secondary_qty_at_date"
     )
 
+    valuation_display_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Secondary UoM",
+        compute="_compute_valuation_display_uom_id",
+    )
+
+    @api.depends("uom_id", "secondary_uom_id")
+    def _compute_valuation_display_uom_id(self):
+        for record in self:
+            record.valuation_display_uom_id = (
+                record.product_tmpl_id.secondary_uom_id or record.product_tmpl_id.uom_id
+            )
+
     def _compute_secondary_qty_at_date(self):
         for record in self:
             record.secondary_qty_at_date = record.convert_secondary_uom(
-                record.qty_at_date, record.uom_id, record.secondary_uom_id
+                record.qty_at_date,
+                record.uom_id,
+                record.secondary_uom_id or record.uom_id,
+                record.secondary_uom_ratio,
             )
 
-    def convert_secondary_uom(self, qty, input_uom_id, output_uom_id):
+    def convert_secondary_price(
+        self, price, input_uom_id, output_uom_id, secondary_uom_ratio
+    ):
+        return float_round(
+            self.convert_secondary_uom(
+                price, output_uom_id, input_uom_id, secondary_uom_ratio
+            ),
+            precision_digits=2,
+        )
+
+    def convert_secondary_uom(
+        self, qty, input_uom_id, output_uom_id, secondary_uom_ratio
+    ):
         if (
             not self.secondary_uom_id
             or input_uom_id.category_id.id == output_uom_id.category_id.id
@@ -26,24 +57,12 @@ class ProductProduct(models.Model):
             )
 
         if input_uom_id.category_id.id == self.uom_id.category_id.id:
-            ref_input_uom = self.uom_id
-            ref_output_uom = self.secondary_uom_id
-            ratio = self.secondary_uom_ratio
+            ratio = secondary_uom_ratio
         else:
-            ref_input_uom = self.secondary_uom_id
-            ref_output_uom = self.uom_id
-            ratio = 1 / self.secondary_uom_ratio
+            if not secondary_uom_ratio:
+                raise ValidationError(_("The Secondary UoM Ratio can not be zero."))
+            ratio = 1 / secondary_uom_ratio
 
-        input_qty = (
-            qty
-            if input_uom_id.id == ref_input_uom.id
-            else input_uom_id._compute_quantity(qty, ref_input_uom)
-        )
+        ref_output_uom_qty = qty * ratio
 
-        ref_output_uom_qty = input_qty * ratio
-
-        return (
-            ref_output_uom_qty
-            if output_uom_id.id == ref_output_uom.id
-            else ref_output_uom._compute_quantity(ref_output_uom_qty, output_uom_id)
-        )
+        return ref_output_uom_qty

--- a/product_eggemoa/models/sale_order_line.py
+++ b/product_eggemoa/models/sale_order_line.py
@@ -1,0 +1,63 @@
+from odoo import models, fields, api
+from odoo.addons import decimal_precision
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    secondary_uom_price_unit = fields.Float(
+        string="Invoice UoM Price Unit",
+        digits=decimal_precision.get_precision("Product Price"),
+    )
+
+    secondary_uom_id = fields.Many2one(comodel_name="uom.uom", string="Invoice Uom")
+
+    secondary_uom_ratio = fields.Float(string="Invoice UoM Ratio",)
+
+    secondary_uom_qty = fields.Float(string="Invoice UoM Total Quantity",)
+
+    @api.onchange("product_uom_qty", "secondary_uom_ratio")
+    def _onchange_quantity_info(self):
+        self.secondary_uom_qty = self.product_id.convert_secondary_uom(
+            self.product_uom_qty,
+            self.product_uom,
+            self.secondary_uom_id or self.product_uom,
+            self.secondary_uom_ratio,
+        )
+
+    @api.onchange("secondary_uom_qty")
+    def _onchange_secondary_uom_qty(self):
+        self.secondary_uom_ratio = (
+            self.secondary_uom_qty / self.product_uom_qty
+            if self.product_uom_qty
+            else self.secondary_uom_ratio
+        )
+
+    @api.onchange("product_id")
+    def _onchange_product_id(self):
+        self.secondary_uom_id = (
+            self.product_id.secondary_uom_id or self.product_id.uom_id
+        )
+        self.secondary_uom_ratio = (
+            self.product_id.secondary_uom_ratio
+            if self.product_id.secondary_uom_id
+            else 1
+        )
+
+    @api.onchange("price_unit")
+    def _onchange_price_unit(self):
+        self.secondary_uom_price_unit = self.product_id.convert_secondary_price(
+            self.price_unit,
+            self.product_uom,
+            self.secondary_uom_id or self.product_uom,
+            self.secondary_uom_ratio,
+        )
+
+    @api.onchange("secondary_uom_price_unit", "secondary_uom_ratio")
+    def _onchange_secondary_uom_price_unit(self):
+        self.price_unit = self.product_id.convert_secondary_price(
+            self.secondary_uom_price_unit,
+            self.secondary_uom_id or self.product_uom,
+            self.product_uom,
+            self.secondary_uom_ratio,
+        )

--- a/product_eggemoa/views/account_invoice.xml
+++ b/product_eggemoa/views/account_invoice.xml
@@ -7,13 +7,12 @@
       <field name="inherit_id" ref="account.invoice_form" />
       <field name="arch" type="xml">
         <field name="uom_id" position="after">
+          <field name="secondary_uom_ratio" />
           <field name="secondary_uom_quantity" />
           <field name="secondary_uom_id" />
+          <field name="secondary_uom_price_unit" />
         </field>
-        <field name="quantity" position="attributes">
-          <attribute name="invisible">1</attribute>
-        </field>
-        <field name="uom_id" position="attributes">
+        <field name="price_unit" position="attributes">
           <attribute name="invisible">1</attribute>
         </field>
       </field>

--- a/product_eggemoa/views/product_product.xml
+++ b/product_eggemoa/views/product_product.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <field name="uom_id" position="after">
           <field name="secondary_qty_at_date" />
-          <field name="secondary_uom_id" />
+          <field name="valuation_display_uom_id" />
         </field>
       </field>
     </record>

--- a/product_eggemoa/views/product_template.xml
+++ b/product_eggemoa/views/product_template.xml
@@ -6,15 +6,17 @@
       <field name="model">product.template</field>
       <field name="inherit_id" ref="product.product_template_form_view" />
       <field name="arch" type="xml">
-        <group name="sale" position="inside">
-          <group name="secondary_unit" string="Invoicing Unit">
-            <field name="secondary_uom_id" />
-            <field
-              name="secondary_uom_ratio"
-              attrs="{'required': [('secondary_uom_id', '!=', False)]}"
-            />
-          </group>
-        </group>
+        <notebook position="inside">
+          <page string="Invoicing Unit">
+            <group name="secondary_unit" string="Invoicing Unit">
+              <field name="secondary_uom_id" />
+              <field
+                name="secondary_uom_ratio"
+                attrs="{'required': [('secondary_uom_id', '!=', False)]}"
+              />
+            </group>
+          </page>
+        </notebook>
       </field>
     </record>
   </data>

--- a/product_eggemoa/views/sale_order.xml
+++ b/product_eggemoa/views/sale_order.xml
@@ -1,0 +1,37 @@
+<odoo>
+  <data>
+    <record id="eggemoa_sale_order_form" model="ir.ui.view">
+      <field name="name">Eggemoa Sale Order Form</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form" />
+      <field name="arch" type="xml">
+        <!-- Editing order line tree -->
+        <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']" position="after">
+          <field name="secondary_uom_id" />
+          <field name="secondary_uom_ratio" />
+          <field name="secondary_uom_qty" />
+          <field name="secondary_uom_price_unit" />
+        </xpath>
+        <xpath
+          expr="//field[@name='order_line']/tree/field[@name='price_unit']"
+          position="attributes"
+        >
+          <attribute name="invisible">1</attribute>
+        </xpath>
+        <!-- Editing order line form -->
+        <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+          <field name="secondary_uom_id" required="1" />
+          <field name="secondary_uom_ratio" required="1" />
+          <field name="secondary_uom_qty" required="1" />
+          <field name="secondary_uom_price_unit" required="1" />
+        </xpath>
+        <xpath
+          expr="//field[@name='order_line']/form//field[@name='price_unit']"
+          position="attributes"
+        >
+          <attribute name="invisible">1</attribute>
+        </xpath>
+      </field>
+    </record>
+  </data>
+</odoo>


### PR DESCRIPTION
* [ADD] First module files

* [ADD] Option to inform secondary unit on product template

* [ADD] Replacing invoice fields with secondary unit ones

* [ADD] Adding secondary qty and uom to stock valuation view

* Removed comment

* [FIX] Api depends usage and code improvements

* [IMP] Changing design of invoice calc solution

* [IMP] Adapting code for different user flow

* [ADD] Adding constrain to secondary_uom_ratio

* [FIX] Making sure both default and secondary unit can be used in invoice

* [FIX] FIx stock valuation compute

* [IMP] Increasing flexibility for invoice uom flow

* [FIX] Cases where the quantity in line equals zero

* [IMP] Shortening views xpath

* [IMP] Separating compute functions